### PR TITLE
QSP-12 Unlocked or Mismatched Pragma

### DIFF
--- a/src/contracts/VestingVault.sol
+++ b/src/contracts/VestingVault.sol
@@ -2,7 +2,7 @@
 Original work taken from https://github.com/tapmydata/tap-protocol, which 
 was based on https://gist.github.com/rstormsf/7cfb0c6b7a835c0c67b4a394b4fd9383.
 */
-pragma solidity ^0.8.0;
+pragma solidity 0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/src/contracts/bancor/BancorFormula.sol
+++ b/src/contracts/bancor/BancorFormula.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache License v2.0
 // copied from: https://github.com/bancorprotocol/contracts-solidity/blob/master/solidity/contracts/converter/BancorFormula.sol
-pragma solidity ^0.8.0;
+pragma solidity 0.8.0;
 
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "./IBancorFormula.sol";

--- a/src/contracts/bancor/IBancorFormula.sol
+++ b/src/contracts/bancor/IBancorFormula.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache License v2.0
 // copied from: https://github.com/bancorprotocol/contracts-solidity/blob/master/solidity/contracts/converter/interfaces/IBancorFormula.sol
-pragma solidity ^0.8.0;
+pragma solidity 0.8.0;
 
 /*
     Bancor Formula interface

--- a/src/contracts/farm/MasterFarm.sol
+++ b/src/contracts/farm/MasterFarm.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.4;
+pragma solidity 0.8.0;
 
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";


### PR DESCRIPTION
IBEP20.sol , SafeBEP20.sol removed in previous QSP fixes. Rest of contracts are updated to locked version of 0.8.0.