### PR TITLE
QSP-2 Possible Un-updated Pools State

### DIFF
--- a/src/contracts/farm/MasterFarm.sol
+++ b/src/contracts/farm/MasterFarm.sol
@@ -94,7 +94,7 @@ contract MasterMeme is Ownable {
 
     // Add a new lp to the pool. Can only be called by the owner.
     // XXX DO NOT add the same LP token more than once. Rewards will be messed up if you do.
-    function add(uint256 _allocPoint, IBEP20 _lpToken, uint16 _depositFeeBP, bool _withUpdate) public onlyOwner {
+    function add(uint256 _allocPoint, IBEP20 _lpToken, uint16 _depositFeeBP) public onlyOwner {
         require(_depositFeeBP <= 10000, "add: invalid deposit fee basis points");
 
         massUpdatePools();
@@ -111,7 +111,7 @@ contract MasterMeme is Ownable {
     }
 
     // Update the given pool's meme allocation point and deposit fee. Can only be called by the owner.
-    function set(uint256 _pid, uint256 _allocPoint, uint16 _depositFeeBP, bool _withUpdate) public onlyOwner {
+    function set(uint256 _pid, uint256 _allocPoint, uint16 _depositFeeBP) public onlyOwner {
         require(_depositFeeBP <= 10000, "set: invalid deposit fee basis points");
 
         massUpdatePools();


### PR DESCRIPTION
Removed `_withUpdate parameter` and condition statement where it was used. massUpdatePools() preserved.